### PR TITLE
Pod fixes

### DIFF
--- a/lib/Spreadsheet/ParseExcel.pm
+++ b/lib/Spreadsheet/ParseExcel.pm
@@ -3172,7 +3172,7 @@ Returns the style of an underlined font where the value has the following meanin
 
 Returns the color index for the font. The mapping to an RGB color is defined by each workbook.
 
-The index can be converted to a RGB string using the C<$workbook->ColorIdxToRGB()> Parser method.
+The index can be converted to a RGB string using the C<< $workbook->color_idx_to_rgb() >> method.
 
 (Older versions of C<Spreadsheet::ParseExcel> provided the C<ColorIdxToRGB> class method, which is deprecated.)
 

--- a/lib/Spreadsheet/ParseExcel.pm
+++ b/lib/Spreadsheet/ParseExcel.pm
@@ -3105,6 +3105,9 @@ Returns an array ref of fill pattern and color indexes as follows:
 
     [ $pattern, $front_color, $back_color ]
 
+Fun Excel quirk: if only a background color is set, then the pattern
+is set to solid, and the front and back colors are swapped.
+
 =head2 $format->{Lock}
 
 Returns true if the cell is locked.

--- a/lib/Spreadsheet/ParseExcel/Cell.pm
+++ b/lib/Spreadsheet/ParseExcel/Cell.pm
@@ -186,7 +186,7 @@ See the documentation for Spreadsheet::ParseExcel.
 
 =head1 DESCRIPTION
 
-This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for Spreadsheet::ParseExcel.
+This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for L<Spreadsheet::ParseExcel>.
 
 =head1 Methods
 

--- a/lib/Spreadsheet/ParseExcel/Dump.pm
+++ b/lib/Spreadsheet/ParseExcel/Dump.pm
@@ -330,7 +330,7 @@ See the documentation for Spreadsheet::ParseExcel.
 
 =head1 DESCRIPTION
 
-This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for Spreadsheet::ParseExcel.
+This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for L<Spreadsheet::ParseExcel>.
 
 =head1 AUTHOR
 

--- a/lib/Spreadsheet/ParseExcel/FmtDefault.pm
+++ b/lib/Spreadsheet/ParseExcel/FmtDefault.pm
@@ -197,7 +197,7 @@ See the documentation for Spreadsheet::ParseExcel.
 
 =head1 DESCRIPTION
 
-This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for Spreadsheet::ParseExcel.
+This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for L<Spreadsheet::ParseExcel>.
 
 =head1 AUTHOR
 

--- a/lib/Spreadsheet/ParseExcel/FmtJapan.pm
+++ b/lib/Spreadsheet/ParseExcel/FmtJapan.pm
@@ -186,7 +186,7 @@ See the documentation for Spreadsheet::ParseExcel.
 
 =head1 DESCRIPTION
 
-This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for Spreadsheet::ParseExcel.
+This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for L<Spreadsheet::ParseExcel>.
 
 =head1 AUTHOR
 

--- a/lib/Spreadsheet/ParseExcel/FmtJapan2.pm
+++ b/lib/Spreadsheet/ParseExcel/FmtJapan2.pm
@@ -79,7 +79,7 @@ See the documentation for Spreadsheet::ParseExcel.
 
 =head1 DESCRIPTION
 
-This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for Spreadsheet::ParseExcel.
+This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for L<Spreadsheet::ParseExcel>.
 
 =head1 AUTHOR
 

--- a/lib/Spreadsheet/ParseExcel/FmtUnicode.pm
+++ b/lib/Spreadsheet/ParseExcel/FmtUnicode.pm
@@ -80,7 +80,7 @@ See the documentation for Spreadsheet::ParseExcel.
 
 =head1 DESCRIPTION
 
-This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for Spreadsheet::ParseExcel.
+This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for L<Spreadsheet::ParseExcel>.
 
 =head1 AUTHOR
 

--- a/lib/Spreadsheet/ParseExcel/Font.pm
+++ b/lib/Spreadsheet/ParseExcel/Font.pm
@@ -44,7 +44,7 @@ See the documentation for Spreadsheet::ParseExcel.
 
 =head1 DESCRIPTION
 
-This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for Spreadsheet::ParseExcel.
+This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for L<Spreadsheet::ParseExcel>.
 
 =head1 AUTHOR
 

--- a/lib/Spreadsheet/ParseExcel/Format.pm
+++ b/lib/Spreadsheet/ParseExcel/Format.pm
@@ -44,7 +44,7 @@ See the documentation for Spreadsheet::ParseExcel.
 
 =head1 DESCRIPTION
 
-This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for Spreadsheet::ParseExcel.
+This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for L<Spreadsheet::ParseExcel>.
 
 =head1 AUTHOR
 

--- a/lib/Spreadsheet/ParseExcel/SaveParser/Workbook.pm
+++ b/lib/Spreadsheet/ParseExcel/SaveParser/Workbook.pm
@@ -433,7 +433,7 @@ See the documentation for Spreadsheet::ParseExcel.
 
 =head1 DESCRIPTION
 
-This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for Spreadsheet::ParseExcel.
+This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for L<Spreadsheet::ParseExcel>.
 
 =head1 AUTHOR
 

--- a/lib/Spreadsheet/ParseExcel/SaveParser/Worksheet.pm
+++ b/lib/Spreadsheet/ParseExcel/SaveParser/Worksheet.pm
@@ -68,7 +68,7 @@ See the documentation for Spreadsheet::ParseExcel.
 
 =head1 DESCRIPTION
 
-This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for Spreadsheet::ParseExcel.
+This module is used in conjunction with Spreadsheet::ParseExcel. See the documentation for L<Spreadsheet::ParseExcel>.
 
 =head1 AUTHOR
 

--- a/lib/Spreadsheet/ParseExcel/Workbook.pm
+++ b/lib/Spreadsheet/ParseExcel/Workbook.pm
@@ -151,13 +151,14 @@ sub ParseAbort {
     $self->{_ParseAbort} = $val;
 }
 
-=head2 get_active_sheet()
-
-Return the number of the active (open) worksheet (at the time the workbook
-was saved.  May return undef.
-
-=cut
-
+###############################################################################
+#
+# get_active_sheet()
+#
+# Return the number of the active (open) worksheet (at the time the workbook
+# was saved).  May return undef.
+#
+#
 sub get_active_sheet {
     my $workbook = shift;
 
@@ -294,6 +295,14 @@ The C<using_1904_date()> method returns true if the Excel file is using the 1904
  The Windows version of Excel generally uses the 1900 epoch while the Mac version of Excel generally uses the 1904 epoch.
 
 Returns 0 if the 1900 epoch is in use.
+
+
+=head2 get_active_sheet()
+
+Return the number of the active (open) worksheet (at the time the workbook
+was saved).  May return C<undef>.
+
+=cut
 
 
 =head1 AUTHOR

--- a/lib/Spreadsheet/ParseExcel/Worksheet.pm
+++ b/lib/Spreadsheet/ParseExcel/Worksheet.pm
@@ -549,38 +549,39 @@ sub is_print_comments {
     return $self->{Notes};
 }
 
-=head2 get_tab_color()
-
-Return color index of tab, or undef if not set.
-
-=cut
-
+###############################################################################
+#
+# get_tab_color()
+#
+# Return color index of tab, or undef if not set.
+#
 sub get_tab_color {
     my $worksheet = shift;
 
     return $worksheet->{TabColor};
 }
 
-=head2 is_sheet_hidden()
-
-Return true if sheet is hidden
-
-=cut
-
+###############################################################################
+#
+# is_sheet_hidden()
+#
+# Return true if sheet is hidden
+#
+#
 sub is_sheet_hidden {
     my $worksheet = shift;
 
     return $worksheet->{SheetHidden};
 }
 
-=head2 is_row_hidden($row)
-
-In scalar context, return true if $row is hidden
-In array context, return an array whose elements are true
-if the corresponding row is hidden.
-
-=cut
-
+###############################################################################
+#
+# is_row_hidden($row)
+#
+# In scalar context, return true if $row is hidden
+# In array context, return an array whose elements are true
+# if the corresponding row is hidden.
+#
 sub is_row_hidden {
     my $worksheet = shift;
 
@@ -595,14 +596,14 @@ sub is_row_hidden {
     return $worksheet->{RowHidden}[$row];
 }
 
-=head2 is_col_hidden($col)
-
-In scalar context, return true if $col is hidden
-In array context, return an array whose elements are true
-if the corresponding column is hidden.
-
-=cut
-
+###############################################################################
+#
+# is_col_hidden($col)
+#
+# In scalar context, return true if $col is hidden
+# In array context, return an array whose elements are true
+# if the corresponding column is hidden.
+#
 sub is_col_hidden {
     my $worksheet = shift;
 
@@ -683,7 +684,10 @@ The C<Spreadsheet::ParseExcel::Worksheet> class encapsulates the properties of a
     $worksheet->is_print_black_and_white()
     $worksheet->is_print_draft()
     $worksheet->is_print_comments()
-
+    $worksheet->get_tab_color()
+    $worksheet->is_sheet_hidden()
+    $worksheet->is_row_hidden()
+    $worksheet->is_col_hidden()
 
 =head2 get_cell($row, $col)
 
@@ -1009,6 +1013,34 @@ The C<is_print_comments()> method returns true if the worksheet print "comments"
     my $is_print_comments = $worksheet->is_print_comments();
 
 Returns 0 if the property isn't set.
+
+
+=head2 get_tab_color()
+
+Return color index of tab, or undef if not set.
+
+    my $tab_color = $worksheet->get_tab_color();
+
+
+=head2 is_sheet_hidden()
+
+Return true if sheet is hidden
+
+    my $is_sheet_hidden = $worksheet->is_sheet_hidden()
+
+
+=head2 is_row_hidden($row)
+
+In scalar context, return true if C<$row> is hidden
+In array context, return an array whose elements are true
+if the corresponding row is hidden.
+
+
+=head2 is_col_hidden($col)
+
+In scalar context, return true if C<$col> is hidden
+In array context, return an array whose elements are true
+if the corresponding column is hidden.
 
 
 =head1 AUTHOR

--- a/lib/Spreadsheet/ParseExcel/Worksheet.pm
+++ b/lib/Spreadsheet/ParseExcel/Worksheet.pm
@@ -691,7 +691,7 @@ The C<Spreadsheet::ParseExcel::Worksheet> class encapsulates the properties of a
 
 =head2 get_cell($row, $col)
 
-Return the L</Cell> object at row C<$row> and column C<$col> if it is defined. Otherwise returns undef.
+Return the L<Spreadsheet::ParseExcel::Cell> object at row C<$row> and column C<$col> if it is defined. Otherwise returns undef.
 
     my $cell = $worksheet->get_cell($row, $col);
 


### PR DESCRIPTION
Hello,

This branch fixes a bunch of errors in the documentation.  The first fixes some out-of-order methods that appear before NAME in Worksheet.pm and Workbook.pm.  The second patches fixes a pod error and an actual documentation error (an incorrectly named method). The third is just a simple pod formatting fixes.  The fourth adds links back to the main document (Spreadsheet::ParseExcel) in the modules without any significant documentation.  Please let me know if you'd like me to make any changes.  Thanks for your time and effort and have a great day!

Cheers,
Fitz
