### PR TITLE
col2int: handle columns with >2 characters

### DIFF
--- a/lib/Spreadsheet/ParseExcel/Utility.pm
+++ b/lib/Spreadsheet/ParseExcel/Utility.pm
@@ -1218,14 +1218,14 @@ sub ExcelLocaltime {
 sub col2int {
     my $result = 0;
     my $str    = shift;
-    my $incr   = 0;
+    my $incr   = 1;
 
     for ( my $i = length($str) ; $i > 0 ; $i-- ) {
         my $char = substr( $str, $i - 1 );
         my $curr += ord( lc($char) ) - ord('a') + 1;
-        $curr *= $incr if ($incr);
+        $curr *= $incr;
         $result += $curr;
-        $incr   += 26;
+        $incr   *= 26;
     }
 
     # this is one out as we range 0..x-1 not 1..x


### PR DESCRIPTION
Updated `col2int()` to handle column names with more than 2 characters.

Previously:
- `col2int("ZZ")` returns `701`
- `col2int("AAA")` returns `78`

Updated:
- `col2int("ZZ")` returns `701`
- `col2int("AAA")` returns `702`
