### PR TITLE
fix for saving numbers with leading zeros and values with numbers and the letter E 

### DIFF
--- a/lib/Spreadsheet/ParseExcel/SaveParser/Workbook.pm
+++ b/lib/Spreadsheet/ParseExcel/SaveParser/Workbook.pm
@@ -139,6 +139,9 @@ sub SaveAs {
         my $oWkS = $oBook->{Worksheet}[$iSheet];
         my $oWrS = $oWrEx->addworksheet( $oWkS->{Name} );
 
+        # set add_write_handler to write "0123" and "0E123" etc as strings
+        $oWrS->add_write_handler(qr/^(0[^.]\d*)?(\.\d*)?([\d.]*?[Ee](\d+)?)?$/, \&write_as_string_handler);
+
         #Landscape
         if ( !$oWkS->{Landscape} ) {    # Landscape (0:Horizontal, 1:Vertical)
             $oWrS->set_landscape();
@@ -304,6 +307,12 @@ sub SaveAs {
         }
     }
     return $oWrEx;
+
+    # this function is used by add_write_handler above
+    sub write_as_string_handler {
+        my $worksheet = shift;
+        return $worksheet->write_string(@_);
+    }
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
[Several](https://github.com/runrig/spreadsheet-parseexcel/issues/6) [people](https://github.com/runrig/spreadsheet-parseexcel/issues/3) complained about SaveAs replacing numeric strings as numbers for values like "0123" or "123E456". That is because of the default regexp that Spreadsheet/WriteExcel uses to tell apart numbers from strings. I modified SaveParser/Workbook to use an add_write_handler to write those kind of "pseudo numbers" as strings
