### PR TITLE
Avoid losing cell texts when there is 3-byte "0x00 0x00 0x00" string record before CONTINUE

### DIFF
--- a/lib/Spreadsheet/ParseExcel.pm
+++ b/lib/Spreadsheet/ParseExcel.pm
@@ -2544,7 +2544,19 @@ sub _subStrWk {
     # Extract out any full strings from the current buffer leaving behind a
     # partial string that is continued into the next block, or an empty
     # buffer is no string is continued.
-    while ( length $self->{_buffer} >= 4 ) {
+    #
+    # Why here buffer length is compared against 3 not 4 is because some xls
+    # writers are possible to generate a 3-byte "0x00 0x00 0x00" as a string
+    # record. We understand this seems somewhat non-standard as MS Excel
+    # won't generate that, on the other hand, the xls structure specification
+    # does not really to forbid it. Actually the _convBIFF8String() function
+    # in this file is fine to process such 3-byte zeros. However, we saw
+    # xls files with this 3-byte "0x00 0x00 0x00" right before a CONTINUE
+    # record, and in this case if we compare buffer length against 4 the
+    # Spreadsheet::ParseExcel logic would run into wrong state and lose the
+    # CONTINUE record and cause texts missing from some cells. MS Excel and
+    # Python's xlrd are forgivable and they don't lose the CONTINUE record.
+    while ( length $self->{_buffer} >= 3 ) {
         my ( $str_info, $length, $str_position, $str_length ) =
           _convBIFF8String( $self, $self->{_buffer}, 1 );
 


### PR DESCRIPTION
We see an edge case where the xls file has a 3-byte "0x00 0x00 0x00" string record right before a SST's CONTINUE record, that is like, 

```
... 0x00 0x00 0x00 0x3c ...
```

In this case the Spreadsheet::ParseExcel parser, as it ends processing the preceding record when buffer lengh < 4, it thinks that 3-byte zeros a partial string record rather than a full record, so it runs into a wrong state, and this causes it to lose the CONTINUE record and thus miss texts in cells. 

We tried the same xls file with MS Excel and Python xlrd package. Both are good and do not miss cell texts. 

See also my comments in the commit code. 